### PR TITLE
added extern type to comply with gcc10 change

### DIFF
--- a/src/chanserv.c
+++ b/src/chanserv.c
@@ -679,7 +679,7 @@ enum note_visible_type
     NOTE_VIS_PRIVILEGED
 };
 
-struct io_fd *socket_io_fd;
+extern struct io_fd *socket_io_fd;
 extern struct cManagerNode cManager;
 
 struct note_type

--- a/src/log.c
+++ b/src/log.c
@@ -27,7 +27,7 @@
 #define Block  4096
 #define MAXLOGSEARCHLENGTH 10000
 
-struct userNode *chanserv;
+extern struct userNode *chanserv;
 
 struct logDestination;
 


### PR DESCRIPTION
gcc10 changed how it handled duplicate global definitions by requiring the extern type on all but one definition. I built
this with gcc12.2.0 on Debian 12 with no problems. This should address issue #43 