### PR TITLE
Handle SIGTERM with graceful shutdown like SIGINT

### DIFF
--- a/src/ioset.c
+++ b/src/ioset.c
@@ -23,6 +23,8 @@
 #include "timeq.h"
 #include "saxdb.h"
 #include "conf.h"
+#include "hash.h"   /* for self */
+#include "proto.h"  /* for irc_squit */
 
 #ifdef HAVE_FCNTL_H
 #include <fcntl.h>
@@ -86,6 +88,7 @@ extern int uplink_connect(void);
 int clock_skew;
 int do_write_dbs;
 int do_reopen;
+int do_exit;
 static struct io_engine *engine;
 static struct io_fd *active_fd;
 
@@ -603,6 +606,13 @@ ioset_run(void) {
             extern char *services_config;
             conf_read(services_config);
             do_reopen = 0;
+        }
+        if (do_exit) {
+            log_module(MAIN_LOG, LOG_INFO, "Saving databases and exiting on signal.");
+            saxdb_write_all(NULL);
+            irc_squit(self, "Exiting on signal from console.", NULL);
+            quit_services = 1;
+            do_exit = 0;
         }
     }
 }

--- a/src/ioset.h
+++ b/src/ioset.h
@@ -46,6 +46,7 @@ struct io_fd {
 };
 extern int do_write_dbs;
 extern int do_reopen;
+extern int do_exit;
 
 void ioset_init(void);
 struct io_fd *ioset_add(int fd);

--- a/src/main.c
+++ b/src/main.c
@@ -132,6 +132,7 @@ int main(int argc, char *argv[])
     sigaction(SIGHUP, &sv, NULL);
     sv.sa_handler = sigaction_exit;
     sigaction(SIGINT, &sv, NULL);
+    sigaction(SIGTERM, &sv, NULL);
     sv.sa_handler = sigaction_writedb;
     sigaction(SIGQUIT, &sv, NULL);
     sv.sa_handler = sigaction_wait;

--- a/src/main.c
+++ b/src/main.c
@@ -66,15 +66,9 @@ void sigaction_writedb(int x)
     do_write_dbs = 1;
 }
 
-void sigaction_exit(int x)
+void sigaction_exit(UNUSED_ARG(int x))
 {
-#ifndef HAVE_STRSIGNAL
-    log_module(MAIN_LOG, LOG_INFO, "Signal %d -- exiting.", x);
-#else
-    log_module(MAIN_LOG, LOG_INFO, "%s -- exiting.", strsignal(x));
-#endif
-    irc_squit(self, "Exiting on signal from console.", NULL);
-    quit_services = 1;
+    do_exit = 1;
 }
 
 void sigaction_wait(UNUSED_ARG(int x))
@@ -291,6 +285,9 @@ int main(int argc, char *argv[])
         now = time(NULL);
         srand(now);
         ioset_run();
+        /* Save databases on clean shutdown (e.g., SIGTERM from docker stop) */
+        log_module(MAIN_LOG, LOG_INFO, "Saving databases before exit.");
+        saxdb_write_all(NULL);
     }
     return 0;
 }


### PR DESCRIPTION
SIGTERM now triggers the same sigaction_exit handler as SIGINT, allowing clean shutdown when receiving kill or docker stop.

This help with running inside Docker, where sigint is sent, and it was just killing without saving the db