### PR TITLE
Modernize rlimits defaults and make LOG_FATAL flush saxdb

### DIFF
--- a/docker/x3.conf-dist
+++ b/docker/x3.conf-dist
@@ -756,11 +756,59 @@
     };
 };
 
-"rlimits" {
-    "data" "50M";
-    "stack" "6M";
-    "vmem" "100M";
-};
+/* Resource limits applied via setrlimit() at startup.
+ *
+ * By default, no "rlimits" block is active — X3 inherits system
+ * defaults (typically unlimited on modern Linux, managed by cgroups
+ * or the container runtime). This is the recommended setup: let the
+ * OS handle it.
+ *
+ * If you want in-process rlimits as a runaway-bug tripwire, uncomment
+ * ONE block below. Sized for common network scales.
+ *
+ * vmem is address space (RLIMIT_AS), not RSS — mmap'd GeoIP, slab
+ * arenas, and shared libraries all count toward it, so it needs
+ * significant headroom above expected RSS. data is the heap cap
+ * (RLIMIT_DATA). stack is per-thread (RLIMIT_STACK). Undersized
+ * rlimits are a common cause of "X3 crashed during burst" — if you
+ * set them too low, X3 calls LOG_FATAL on allocation failure and
+ * exits.
+ *
+ * Size tier  Users    data    stack   vmem
+ * ---------  -----    ----    -----   ----
+ * small      ~10k     256M    16M     512M
+ * medium     ~50k     512M    16M     1500M
+ * large      ~100k    768M    32M     2G
+ * xl         ~200k    1G      32M     4G
+ */
+
+// ~10k users / small network or testnet
+//"rlimits" {
+//    "data"  "256M";
+//    "stack" "16M";
+//    "vmem"  "512M";
+//};
+
+// ~50k users / medium network
+//"rlimits" {
+//    "data"  "512M";
+//    "stack" "16M";
+//    "vmem"  "1500M";
+//};
+
+// ~100k users / large network
+//"rlimits" {
+//    "data"  "768M";
+//    "stack" "32M";
+//    "vmem"  "2G";
+//};
+
+// ~200k users / largest feasibly reasonable network
+//"rlimits" {
+//    "data"  "1G";
+//    "stack" "32M";
+//    "vmem"  "4G";
+//};
 
 /* MAIL (if and how X3 sends mail ) *********************************
  * Mainly Authserv/Nickserv send mail, See the Nickserv

--- a/src/log.c
+++ b/src/log.c
@@ -610,8 +610,22 @@ log_module(struct log_type *type, enum log_severity sev, const char *format, ...
     }
     --type->depth;
     if (sev == LOG_FATAL) {
+        static int fatal_in_progress = 0;
         assert(0 && "fatal message logged");
-        _exit(1);
+        /* First fatal: exit() so atexit handlers run — in particular
+         * saxdb_write_all, to preserve database state on conditions
+         * like RLIMIT_AS mmap exhaustion. saxdb writes atomically
+         * (tmp file + rename), so an interrupted flush can't corrupt
+         * the existing on-disk database.
+         *
+         * Nested fatal (e.g. flush itself hits another allocation
+         * failure): _exit() to avoid exit-within-exit UB. We accept
+         * losing the current flush — the prior timer-driven auto-save
+         * is still valid. */
+        if (fatal_in_progress)
+            _exit(1);
+        fatal_in_progress = 1;
+        exit(1);
     }
 }
 

--- a/x3.conf.example
+++ b/x3.conf.example
@@ -767,11 +767,59 @@
     };
 };
 
-"rlimits" {
-    "data" "50M";
-    "stack" "6M";
-    "vmem" "100M";
-};
+/* Resource limits applied via setrlimit() at startup.
+ *
+ * By default, no "rlimits" block is active — X3 inherits system
+ * defaults (typically unlimited on modern Linux, managed by cgroups
+ * or the container runtime). This is the recommended setup: let the
+ * OS handle it.
+ *
+ * If you want in-process rlimits as a runaway-bug tripwire, uncomment
+ * ONE block below. Sized for common network scales.
+ *
+ * vmem is address space (RLIMIT_AS), not RSS — mmap'd GeoIP, slab
+ * arenas, and shared libraries all count toward it, so it needs
+ * significant headroom above expected RSS. data is the heap cap
+ * (RLIMIT_DATA). stack is per-thread (RLIMIT_STACK). Undersized
+ * rlimits are a common cause of "X3 crashed during burst" — if you
+ * set them too low, X3 calls LOG_FATAL on allocation failure and
+ * exits.
+ *
+ * Size tier  Users    data    stack   vmem
+ * ---------  -----    ----    -----   ----
+ * small      ~10k     256M    16M     512M
+ * medium     ~50k     512M    16M     1500M
+ * large      ~100k    768M    32M     2G
+ * xl         ~200k    1G      32M     4G
+ */
+
+// ~10k users / small network or testnet
+//"rlimits" {
+//    "data"  "256M";
+//    "stack" "16M";
+//    "vmem"  "512M";
+//};
+
+// ~50k users / medium network
+//"rlimits" {
+//    "data"  "512M";
+//    "stack" "16M";
+//    "vmem"  "1500M";
+//};
+
+// ~100k users / large network
+//"rlimits" {
+//    "data"  "768M";
+//    "stack" "32M";
+//    "vmem"  "2G";
+//};
+
+// ~200k users / largest feasibly reasonable network
+//"rlimits" {
+//    "data"  "1G";
+//    "stack" "32M";
+//    "vmem"  "4G";
+//};
 
 /* MAIL (if and how X3 sends mail ) *********************************
  * Mainly Authserv/Nickserv send mail, See the Nickserv


### PR DESCRIPTION
## Summary

- Remove the active `rlimits {}` block from both example configs; X3 now inherits system limits by default. The stock values (data 50M / stack 6M / vmem 100M) were sized for 2005-era networks and cause X3 to LOG_FATAL during burst on any modern network — GeoIP mmap alone can push vmem near the 100M ceiling before a single burst user is accepted.
- Keep four commented-out tier examples (10k / 50k / 100k / 200k users) for admins who want in-process rlimits as a runaway-bug tripwire.
- `LOG_FATAL` now calls `exit()` instead of `_exit()`, so atexit handlers run — specifically `saxdb_write_all`, preserving database state on fatal exit. saxdb already writes atomically via tmp file + rename (`saxdb.c:141-163`), so an interrupted flush can't corrupt the existing on-disk database.
- Add a static re-entry guard: if the flush itself triggers another LOG_FATAL (nested allocation failure), fall back to `_exit()` to avoid exit-within-exit UB per C11 §7.22.4.4.

## Motivation

On modern systems with cgroups / container-level memory management, an in-process `setrlimit` block is redundant at best and a footgun at worst. The shipped vmem of 100M isn't enough for a meaningful network once you factor in GeoIP mmap, slab arenas, and shared libraries (all of which count toward RLIMIT_AS). The result is X3 dying during burst with a LOG_FATAL that looks like an unexplained crash to operators who haven't checked `/proc/<pid>/status`.

## Test plan

- [ ] Start X3 with no `rlimits {}` block — confirm it runs with system defaults
- [ ] Uncomment the small tier (10k) — confirm setrlimit values show up in `/proc/<pid>/limits`
- [ ] Simulate a LOG_FATAL (e.g. `log_module(MAIN_LOG, LOG_FATAL, "test")`) and verify saxdb `.new` → rename happens before exit
- [ ] Simulate nested LOG_FATAL during saxdb flush and verify clean `_exit` rather than recursive atexit processing

🤖 Generated with [Claude Code](https://claude.com/claude-code)