### PR TITLE
chanserv: mark registered channels +R on the wire; split z (persist) from R (registered)

### DIFF
--- a/src/chanserv.c
+++ b/src/chanserv.c
@@ -8439,7 +8439,8 @@ handle_join(struct modeNode *mNode, UNUSED_ARG(void *extra))
     if(channel->members.used > cData->max)
         cData->max = channel->members.used;
 
-    /* Self-heal the ircd's +R (MODE_REGISTERED) marker for a channel we
+    /* Self-heal the ircd's registered marker (MODE_REGISTERED, wire +z
+     * for now -- see the z->R transition plan) for a channel we
      * know is registered (channel_info set, not suspended -- both already
      * checked above) but which the ircd doesn't currently show as such.
      * This covers ircd restarts (fresh channel, no memory of +R), X3

--- a/src/chanserv.c
+++ b/src/chanserv.c
@@ -1737,9 +1737,11 @@ unregister_channel(struct chanData *channel, const char *reason)
 
     /* Always clear the ircd's registration marker (+R) on unregistration,
      * independent of off_channel (which only governs whether ChanServ
-     * itself leaves the channel). */
+     * itself leaves the channel).  Clear the persist exmode (+z) too:
+     * an unregistered channel must be able to die when it empties (the
+     * ircd schedules the destruct when -z lands on an empty channel). */
     mod_chanmode_init(&change);
-    change.modes_clear |= MODE_REGISTERED;
+    change.modes_clear |= MODE_REGISTERED | MODE_PERSIST;
     mod_chanmode_announce(chanserv, channel->channel, &change);
 
     wipe_adduser_pending(channel->channel, NULL);
@@ -2620,8 +2622,13 @@ static CHANSERV_FUNC(cmd_register)
     cData->modes = chanserv_conf.default_modes;
     /* Always announce the ircd's registration marker (+R) on registration;
      * off_channel only governs whether ChanServ itself joins/leaves the
-     * channel below, not whether the ircd learns it's registered. */
+     * channel below, not whether the ircd learns it's registered.
+     * With off_channel>0 there is no bot presence to hold the channel
+     * open, so also set the persist exmode (+z) -- its original intended
+     * use -- to keep the registered channel alive while empty. */
     cData->modes.modes_set |= MODE_REGISTERED;
+    if(off_channel > 0)
+        cData->modes.modes_set |= MODE_PERSIST;
     if (IsOffChannel(cData))
     {
         mod_chanmode_announce(chanserv, channel, &cData->modes);
@@ -2811,14 +2818,18 @@ static CHANSERV_FUNC(cmd_move)
     else if(!IsSuspended(channel->channel_info))
         chanserv_join = 1;
 
-    /* Clear MODE_REGISTERED from old channel, add it to new. Always, not
-     * just under off_channel -- the ircd's +R must follow registration
-     * regardless of whether ChanServ itself occupies the channel. */
+    /* Clear the server-managed markers from the old channel, add them to
+     * the new. Always, not just under off_channel -- the ircd's +R must
+     * follow registration regardless of whether ChanServ itself occupies
+     * the channel. The persist exmode (+z) moves too, but is only SET
+     * when off_channel>0 (bot presence otherwise holds the channel). */
     change.argc = 0;
-    change.modes_clear = MODE_REGISTERED;
+    change.modes_clear = MODE_REGISTERED | MODE_PERSIST;
     mod_chanmode_announce(chanserv, channel, &change);
     change.modes_clear = 0;
     change.modes_set = MODE_REGISTERED;
+    if(off_channel > 0)
+        change.modes_set |= MODE_PERSIST;
     mod_chanmode_announce(chanserv, target, &change);
 
     /* Move the channel_info to the target channel; it
@@ -8439,8 +8450,8 @@ handle_join(struct modeNode *mNode, UNUSED_ARG(void *extra))
     if(channel->members.used > cData->max)
         cData->max = channel->members.used;
 
-    /* Self-heal the ircd's registered marker (MODE_REGISTERED, wire +z
-     * for now -- see the z->R transition plan) for a channel we
+    /* Self-heal the ircd's server-managed markers (+R always; +z persist
+     * when off_channel>0, since no bot presence then) for a channel we
      * know is registered (channel_info set, not suspended -- both already
      * checked above) but which the ircd doesn't currently show as such.
      * This covers ircd restarts (fresh channel, no memory of +R), X3
@@ -8454,12 +8465,16 @@ handle_join(struct modeNode *mNode, UNUSED_ARG(void *extra))
      * (burst or not) actually triggers the wire MODE -- every later
      * handle_join() call in the same burst sees MODE_REGISTERED already
      * set and no-ops here. */
-    if(!(channel->modes & MODE_REGISTERED))
     {
-        struct mod_chanmode reg_change;
-        mod_chanmode_init(&reg_change);
-        reg_change.modes_set = MODE_REGISTERED;
-        mod_chanmode_announce(chanserv, channel, &reg_change);
+        unsigned int needed = MODE_REGISTERED
+            | ((off_channel > 0) ? MODE_PERSIST : 0);
+        if((channel->modes & needed) != needed)
+        {
+            struct mod_chanmode reg_change;
+            mod_chanmode_init(&reg_change);
+            reg_change.modes_set = needed & ~channel->modes;
+            mod_chanmode_announce(chanserv, channel, &reg_change);
+        }
     }
 
 #ifdef notdef
@@ -9644,8 +9659,11 @@ chanserv_channel_read(const char *key, struct record_data *hir)
         /* Always re-assert +R on DB-load reregistration; see
          * unregister_channel()/register path. When this block doesn't run
          * at all (channel has no stored KEY_MODES), handle_join()'s
-         * heal-on-join covers it instead. */
+         * heal-on-join covers it instead. +z persist rides along when
+         * off_channel>0 (no bot presence to keep the channel alive). */
         cData->modes.modes_set |= MODE_REGISTERED;
+        if(off_channel > 0)
+            cData->modes.modes_set |= MODE_PERSIST;
         if(cData->modes.argc > 1)
             cData->modes.argc = 1;
         mod_chanmode_announce(chanserv, cNode, &cData->modes);

--- a/src/chanserv.c
+++ b/src/chanserv.c
@@ -1735,12 +1735,12 @@ unregister_channel(struct chanData *channel, const char *reason)
 
     timeq_del(0, NULL, channel, TIMEQ_IGNORE_FUNC | TIMEQ_IGNORE_WHEN);
 
-    if(off_channel > 0)
-    {
-      mod_chanmode_init(&change);
-      change.modes_clear |= MODE_REGISTERED;
-      mod_chanmode_announce(chanserv, channel->channel, &change);
-    }
+    /* Always clear the ircd's registration marker (+R) on unregistration,
+     * independent of off_channel (which only governs whether ChanServ
+     * itself leaves the channel). */
+    mod_chanmode_init(&change);
+    change.modes_clear |= MODE_REGISTERED;
+    mod_chanmode_announce(chanserv, channel->channel, &change);
 
     wipe_adduser_pending(channel->channel, NULL);
 
@@ -2618,8 +2618,10 @@ static CHANSERV_FUNC(cmd_register)
     cData = register_channel(channel, user->handle_info->handle);
     scan_user_presence(add_channel_user(cData, handle, UL_OWNER, 0, NULL, 0), NULL);
     cData->modes = chanserv_conf.default_modes;
-    if(off_channel > 0)
-      cData->modes.modes_set |= MODE_REGISTERED;
+    /* Always announce the ircd's registration marker (+R) on registration;
+     * off_channel only governs whether ChanServ itself joins/leaves the
+     * channel below, not whether the ircd learns it's registered. */
+    cData->modes.modes_set |= MODE_REGISTERED;
     if (IsOffChannel(cData))
     {
         mod_chanmode_announce(chanserv, channel, &cData->modes);
@@ -2809,16 +2811,15 @@ static CHANSERV_FUNC(cmd_move)
     else if(!IsSuspended(channel->channel_info))
         chanserv_join = 1;
 
-    if(off_channel > 0)
-    {
-        /* Clear MODE_REGISTERED from old channel, add it to new. */
-        change.argc = 0;
-        change.modes_clear = MODE_REGISTERED;
-        mod_chanmode_announce(chanserv, channel, &change);
-        change.modes_clear = 0;
-        change.modes_set = MODE_REGISTERED;
-        mod_chanmode_announce(chanserv, target, &change);
-    }
+    /* Clear MODE_REGISTERED from old channel, add it to new. Always, not
+     * just under off_channel -- the ircd's +R must follow registration
+     * regardless of whether ChanServ itself occupies the channel. */
+    change.argc = 0;
+    change.modes_clear = MODE_REGISTERED;
+    mod_chanmode_announce(chanserv, channel, &change);
+    change.modes_clear = 0;
+    change.modes_set = MODE_REGISTERED;
+    mod_chanmode_announce(chanserv, target, &change);
 
     /* Move the channel_info to the target channel; it
        shouldn't be necessary to clear timeq callbacks
@@ -8438,6 +8439,28 @@ handle_join(struct modeNode *mNode, UNUSED_ARG(void *extra))
     if(channel->members.used > cData->max)
         cData->max = channel->members.used;
 
+    /* Self-heal the ircd's +R (MODE_REGISTERED) marker for a channel we
+     * know is registered (channel_info set, not suspended -- both already
+     * checked above) but which the ircd doesn't currently show as such.
+     * This covers ircd restarts (fresh channel, no memory of +R), X3
+     * restarts racing a channel's first post-restart JOIN before the
+     * BURST/DB-load path re-set it, and channel re-creation. Unlike the
+     * join-flood/burst guards below (dynamic-limit timer resets,
+     * automode, greetings) this isn't gated on user->uplink->burst: it
+     * sends no message to the user and touches no timer, it only
+     * corrects channel state, and mod_chanmode_announce() applies the
+     * change to channel->modes immediately, so only the first joiner
+     * (burst or not) actually triggers the wire MODE -- every later
+     * handle_join() call in the same burst sees MODE_REGISTERED already
+     * set and no-ops here. */
+    if(!(channel->modes & MODE_REGISTERED))
+    {
+        struct mod_chanmode reg_change;
+        mod_chanmode_init(&reg_change);
+        reg_change.modes_set = MODE_REGISTERED;
+        mod_chanmode_announce(chanserv, channel, &reg_change);
+    }
+
 #ifdef notdef
     /* Check for bans.  If they're joining through a ban, one of two
      * cases applies:
@@ -9617,8 +9640,11 @@ chanserv_channel_read(const char *key, struct record_data *hir)
        && (modes = mod_chanmode_parse(cNode, argv, argc, MCP_KEY_FREE, 0))) 
     {
         cData->modes = *modes;
-        if(off_channel > 0)
-          cData->modes.modes_set |= MODE_REGISTERED;
+        /* Always re-assert +R on DB-load reregistration; see
+         * unregister_channel()/register path. When this block doesn't run
+         * at all (channel has no stored KEY_MODES), handle_join()'s
+         * heal-on-join covers it instead. */
+        cData->modes.modes_set |= MODE_REGISTERED;
         if(cData->modes.argc > 1)
             cData->modes.argc = 1;
         mod_chanmode_announce(chanserv, cNode, &cData->modes);

--- a/src/hash.c
+++ b/src/hash.c
@@ -555,7 +555,9 @@ wipeout_channel(struct chanNode *cNode, time_t new_time, char **modes, unsigned 
     strcpy(orig_upass, cNode->upass);
     strcpy(orig_apass, cNode->apass);
     cNode->modes = 0;
-    mod_chanmode(NULL, cNode, modes, modec, 0);
+    /* burst data IS server-origin; without the flag one unknown letter
+     * aborts the whole parse and strands modes at zero */
+    mod_chanmode(NULL, cNode, modes, modec, MCP_FROM_SERVER);
     cNode->timestamp = new_time;
 
     /* remove our old ban list, replace it with the new one */

--- a/src/hash.h
+++ b/src/hash.h
@@ -42,7 +42,7 @@
 #define MODE_REGONLY            0x00001000 /* ircu +r */
 #define MODE_NOCOLORS           0x00002000 /* +c */
 #define MODE_NOCTCPS            0x00004000 /* +C */
-#define MODE_REGISTERED         0x00008000 /* server-settable channel registration marker; emitted as +z (nefarious persist exmode doubles as the registered keep-alive), parsed from both +z and +R pending the z->R transition -- NOT Bahamut +r */
+#define MODE_REGISTERED         0x00008000 /* server-settable channel registration marker; wire letter +R (nefarious channel.c MODE_REGISTERED) -- NOT Bahamut +r, and NOT the fork's +z persist exmode */
 #define MODE_STRIPCOLOR         0x00010000 /* +S Strip mirc color codes */
 #define MODE_MODUNREG           0x00020000 /* +M mod unregister */
 #define MODE_NONOTICE           0x00040000 /* +N no notices */
@@ -56,6 +56,10 @@
 #define MODE_APASS		0x04000000 /* +A adminpass */
 #define MODE_UPASS		0x08000000 /* +U userpass */
 #define MODE_ADMINSONLY         0x10000000 /* +a Admins only */
+#define MODE_PERSIST            0x20000000 /* +z nefarious persist exmode (server-settable; channel survives while
+                                            * empty). ChanServ sets it alongside +R when off_channel>0 -- i.e.
+                                            * exactly when no bot presence holds the channel open. NOT the
+                                            * registered marker; that is MODE_REGISTERED (+R). */
 #define MODE_REMOVE             0x80000000
 
 #define FLAGS_OPER		0x00000001 /* Operator +o */

--- a/src/hash.h
+++ b/src/hash.h
@@ -42,7 +42,7 @@
 #define MODE_REGONLY            0x00001000 /* ircu +r */
 #define MODE_NOCOLORS           0x00002000 /* +c */
 #define MODE_NOCTCPS            0x00004000 /* +C */
-#define MODE_REGISTERED         0x00008000 /* Bahamut +r */
+#define MODE_REGISTERED         0x00008000 /* server-settable channel registration marker; wire letter +R (nefarious channel.c MODE_REGISTERED) -- NOT Bahamut +r, and NOT the fork's +z persist exmode */
 #define MODE_STRIPCOLOR         0x00010000 /* +S Strip mirc color codes */
 #define MODE_MODUNREG           0x00020000 /* +M mod unregister */
 #define MODE_NONOTICE           0x00040000 /* +N no notices */

--- a/src/hash.h
+++ b/src/hash.h
@@ -42,7 +42,7 @@
 #define MODE_REGONLY            0x00001000 /* ircu +r */
 #define MODE_NOCOLORS           0x00002000 /* +c */
 #define MODE_NOCTCPS            0x00004000 /* +C */
-#define MODE_REGISTERED         0x00008000 /* server-settable channel registration marker; wire letter +R (nefarious channel.c MODE_REGISTERED) -- NOT Bahamut +r, and NOT the fork's +z persist exmode */
+#define MODE_REGISTERED         0x00008000 /* server-settable channel registration marker; emitted as +z (nefarious persist exmode doubles as the registered keep-alive), parsed from both +z and +R pending the z->R transition -- NOT Bahamut +r */
 #define MODE_STRIPCOLOR         0x00010000 /* +S Strip mirc color codes */
 #define MODE_MODUNREG           0x00020000 /* +M mod unregister */
 #define MODE_NONOTICE           0x00040000 /* +N no notices */

--- a/src/proto-p10.c
+++ b/src/proto-p10.c
@@ -2034,7 +2034,7 @@ static CMD_FUNC(cmd_burst)
     if (!cData) {
         if (cNode->modes & MODE_REGISTERED) {
             irc_join(opserv, cNode);
-            irc_mode(opserv, cNode, "-z");
+            irc_mode(opserv, cNode, "-R");
             irc_part(opserv, cNode, "");
         }
     }
@@ -3617,7 +3617,13 @@ mod_chanmode_parse(struct chanNode *channel, char **modes, unsigned int argc, un
         case 'a': do_chan_mode(MODE_ADMINSONLY); break;
         case 'Z': do_chan_mode(MODE_SSLONLY); break;
 	case 'L': do_chan_mode(MODE_HIDEMODE); break;
-	case 'z':
+	case 'R':
+	  /* MODE_REGISTERED wire letter (nefarious channel.c MODE_REGISTERED,
+	   * server-origin-only). MCP_REGISTERED is passed by the ChanServ
+	   * MODE-lock/mode-command call sites to forbid a user-typed mode
+	   * string from toggling registration state; server-origin calls
+	   * (cmd_mode, AddChannel/BURST via MCP_FROM_SERVER) don't set it,
+	   * so the ircd is free to correct our copy. */
 	  if (!(flags & MCP_REGISTERED)) {
               do_chan_mode(MODE_REGISTERED);
 	  } else {
@@ -3625,6 +3631,13 @@ mod_chanmode_parse(struct chanNode *channel, char **modes, unsigned int argc, un
               return NULL;
 	  }
 	  break;
+	/* 'z' intentionally NOT a case here: on the fork it is the persist
+	 * exmode, unrelated to registration. Falling through to the
+	 * default case makes it silently ignored on server-origin mode
+	 * strings (MCP_FROM_SERVER, e.g. incoming BURST/MODE) and rejects
+	 * the whole string on user-typed ones -- identical treatment to
+	 * every other letter this parser doesn't recognize. Do NOT parse
+	 * it as MODE_REGISTERED here. */
 #undef do_chan_mode
         case 'l':
             if (add) {
@@ -3850,7 +3863,7 @@ mod_chanmode_announce(struct userNode *who, struct chanNode *channel, struct mod
         DO_MODE_CHAR(NOAMSG, 'T');
         DO_MODE_CHAR(OPERSONLY, 'O');
         DO_MODE_CHAR(ADMINSONLY, 'a');
-        DO_MODE_CHAR(REGISTERED, 'z');
+        DO_MODE_CHAR(REGISTERED, 'R');
         DO_MODE_CHAR(SSLONLY, 'Z');
 	DO_MODE_CHAR(HIDEMODE, 'L');
 #undef DO_MODE_CHAR
@@ -3907,7 +3920,7 @@ mod_chanmode_announce(struct userNode *who, struct chanNode *channel, struct mod
         DO_MODE_CHAR(NOAMSG, 'T');
         DO_MODE_CHAR(OPERSONLY, 'O');
         DO_MODE_CHAR(ADMINSONLY, 'a');
-        DO_MODE_CHAR(REGISTERED, 'z');
+        DO_MODE_CHAR(REGISTERED, 'R');
         DO_MODE_CHAR(SSLONLY, 'Z');
 	DO_MODE_CHAR(HIDEMODE, 'L');
 #undef DO_MODE_CHAR
@@ -3983,7 +3996,7 @@ mod_chanmode_format(struct mod_chanmode *change, char *outbuff)
         DO_MODE_CHAR(NOAMSG, 'T');
         DO_MODE_CHAR(OPERSONLY, 'O');
         DO_MODE_CHAR(ADMINSONLY, 'a');
-        DO_MODE_CHAR(REGISTERED, 'z');
+        DO_MODE_CHAR(REGISTERED, 'R');
         DO_MODE_CHAR(SSLONLY, 'Z');
 	DO_MODE_CHAR(HIDEMODE, 'L');
 #undef DO_MODE_CHAR
@@ -4008,7 +4021,7 @@ mod_chanmode_format(struct mod_chanmode *change, char *outbuff)
         DO_MODE_CHAR(NOAMSG, 'T');
         DO_MODE_CHAR(OPERSONLY, 'O');
         DO_MODE_CHAR(ADMINSONLY, 'a');
-        DO_MODE_CHAR(REGISTERED, 'z');
+        DO_MODE_CHAR(REGISTERED, 'R');
         DO_MODE_CHAR(SSLONLY, 'Z');
 	DO_MODE_CHAR(HIDEMODE, 'L');
 
@@ -4074,7 +4087,9 @@ clear_chanmode(struct chanNode *channel, const char *modes)
         case 'T': cleared |= MODE_NOAMSG; break;
         case 'O': cleared |= MODE_OPERSONLY; break;
         case 'a': cleared |= MODE_ADMINSONLY; break;
-        case 'z': cleared |= MODE_REGISTERED; break;
+        case 'R': cleared |= MODE_REGISTERED; break;
+        /* 'z' is the fork's persist exmode, not MODE_REGISTERED; unmatched
+         * letters here are already silently ignored (no default needed). */
         case 'Z': cleared |= MODE_SSLONLY; break;
 	case 'L': cleared |= MODE_HIDEMODE; break;
         }

--- a/src/proto-p10.c
+++ b/src/proto-p10.c
@@ -2032,10 +2032,11 @@ static CMD_FUNC(cmd_burst)
     cData = cNode->channel_info;
 
     if (!cData) {
-        if (cNode->modes & MODE_REGISTERED) {
+        if (cNode->modes & (MODE_REGISTERED | MODE_PERSIST)) {
+            /* Channel is not registered with us but carries server-managed
+             * markers: strip the registration marker AND any stale persist
+             * exmode (only ChanServ sets +z, on registered channels). */
             irc_join(opserv, cNode);
-            /* Strip both registered-marker letters: 'z' is what we emit
-             * today, 'R' may ride along in fork bursts (persist-mirror). */
             irc_mode(opserv, cNode, "-zR");
             irc_part(opserv, cNode, "");
         }
@@ -3619,26 +3620,30 @@ mod_chanmode_parse(struct chanNode *channel, char **modes, unsigned int argc, un
         case 'a': do_chan_mode(MODE_ADMINSONLY); break;
         case 'Z': do_chan_mode(MODE_SSLONLY); break;
 	case 'L': do_chan_mode(MODE_HIDEMODE); break;
-	case 'z': /* X3's historical/current wire letter for this bit (the
-	           * bit itself descends from Bahamut's +r concept; the 'z'
-	           * mapping is X3's own) */
-	case 'R': /* nefarious MODE_REGISTERED marker; fork bursts it once
-	           * the persist-mirror sets the bit */
-	  /* MODE_REGISTERED: parse LIBERALLY (both letters), emit
-	   * conservatively ('z' only -- see mod_chanmode_format below and
-	   * the registered-mode z->R transition plan). On nefarious, 'z'
-	   * is the persist exmode: services-settable only, and X3's
-	   * emitting it on registered channels doubles as the keep-alive
-	   * those channels want. 'R' is upstream's inert registered
-	   * marker, given real semantics on the fork; parsing it too keeps
-	   * us coherent when a fork server bursts +R alongside +z.
-	   * MCP_REGISTERED is passed by the ChanServ MODE-lock/mode-command
-	   * call sites to forbid a user-typed mode string from toggling
-	   * registration state; server-origin calls (cmd_mode,
-	   * AddChannel/BURST via MCP_FROM_SERVER) don't set it, so the
-	   * ircd is free to correct our copy. */
+	case 'R':
+	  /* MODE_REGISTERED wire letter (nefarious channel.c MODE_REGISTERED,
+	   * server-origin-only). MCP_REGISTERED is passed by the ChanServ
+	   * MODE-lock/mode-command call sites to forbid a user-typed mode
+	   * string from toggling registration state; server-origin calls
+	   * (cmd_mode, AddChannel/BURST via MCP_FROM_SERVER) don't set it,
+	   * so the ircd is free to correct our copy. */
 	  if (!(flags & MCP_REGISTERED)) {
               do_chan_mode(MODE_REGISTERED);
+	  } else {
+              mod_chanmode_free(change);
+              return NULL;
+	  }
+	  break;
+	case 'z':
+	  /* Nefarious persist exmode: server-settable-only channel
+	   * keep-alive, tracked as MODE_PERSIST -- NOT the registered
+	   * marker (historical X3 misread it as MODE_REGISTERED).
+	   * Same guard as 'R': user-typed mode strings (MCP_REGISTERED
+	   * call sites, i.e. ChanServ modelock/mode-command) may not
+	   * toggle a server-managed marker; server-origin strings parse
+	   * it so our copy tracks the ircd. */
+	  if (!(flags & MCP_REGISTERED)) {
+              do_chan_mode(MODE_PERSIST);
 	  } else {
               mod_chanmode_free(change);
               return NULL;
@@ -3869,7 +3874,8 @@ mod_chanmode_announce(struct userNode *who, struct chanNode *channel, struct mod
         DO_MODE_CHAR(NOAMSG, 'T');
         DO_MODE_CHAR(OPERSONLY, 'O');
         DO_MODE_CHAR(ADMINSONLY, 'a');
-        DO_MODE_CHAR(REGISTERED, 'z'); /* emit 'z' (not 'R') until the z->R transition; parse accepts both */
+        DO_MODE_CHAR(REGISTERED, 'R');
+        DO_MODE_CHAR(PERSIST, 'z');
         DO_MODE_CHAR(SSLONLY, 'Z');
 	DO_MODE_CHAR(HIDEMODE, 'L');
 #undef DO_MODE_CHAR
@@ -3926,7 +3932,8 @@ mod_chanmode_announce(struct userNode *who, struct chanNode *channel, struct mod
         DO_MODE_CHAR(NOAMSG, 'T');
         DO_MODE_CHAR(OPERSONLY, 'O');
         DO_MODE_CHAR(ADMINSONLY, 'a');
-        DO_MODE_CHAR(REGISTERED, 'z'); /* emit 'z' (not 'R') until the z->R transition; parse accepts both */
+        DO_MODE_CHAR(REGISTERED, 'R');
+        DO_MODE_CHAR(PERSIST, 'z');
         DO_MODE_CHAR(SSLONLY, 'Z');
 	DO_MODE_CHAR(HIDEMODE, 'L');
 #undef DO_MODE_CHAR
@@ -4002,7 +4009,8 @@ mod_chanmode_format(struct mod_chanmode *change, char *outbuff)
         DO_MODE_CHAR(NOAMSG, 'T');
         DO_MODE_CHAR(OPERSONLY, 'O');
         DO_MODE_CHAR(ADMINSONLY, 'a');
-        DO_MODE_CHAR(REGISTERED, 'z'); /* emit 'z' (not 'R') until the z->R transition; parse accepts both */
+        DO_MODE_CHAR(REGISTERED, 'R');
+        DO_MODE_CHAR(PERSIST, 'z');
         DO_MODE_CHAR(SSLONLY, 'Z');
 	DO_MODE_CHAR(HIDEMODE, 'L');
 #undef DO_MODE_CHAR
@@ -4027,7 +4035,8 @@ mod_chanmode_format(struct mod_chanmode *change, char *outbuff)
         DO_MODE_CHAR(NOAMSG, 'T');
         DO_MODE_CHAR(OPERSONLY, 'O');
         DO_MODE_CHAR(ADMINSONLY, 'a');
-        DO_MODE_CHAR(REGISTERED, 'z'); /* emit 'z' (not 'R') until the z->R transition; parse accepts both */
+        DO_MODE_CHAR(REGISTERED, 'R');
+        DO_MODE_CHAR(PERSIST, 'z');
         DO_MODE_CHAR(SSLONLY, 'Z');
 	DO_MODE_CHAR(HIDEMODE, 'L');
 
@@ -4094,7 +4103,7 @@ clear_chanmode(struct chanNode *channel, const char *modes)
         case 'O': cleared |= MODE_OPERSONLY; break;
         case 'a': cleared |= MODE_ADMINSONLY; break;
         case 'R': cleared |= MODE_REGISTERED; break;
-        case 'z': cleared |= MODE_REGISTERED; break; /* current wire letter; 'R' kept for the transition */
+        case 'z': cleared |= MODE_PERSIST; break;
         case 'Z': cleared |= MODE_SSLONLY; break;
 	case 'L': cleared |= MODE_HIDEMODE; break;
         }

--- a/src/proto-p10.c
+++ b/src/proto-p10.c
@@ -2034,7 +2034,9 @@ static CMD_FUNC(cmd_burst)
     if (!cData) {
         if (cNode->modes & MODE_REGISTERED) {
             irc_join(opserv, cNode);
-            irc_mode(opserv, cNode, "-R");
+            /* Strip both registered-marker letters: 'z' is what we emit
+             * today, 'R' may ride along in fork bursts (persist-mirror). */
+            irc_mode(opserv, cNode, "-zR");
             irc_part(opserv, cNode, "");
         }
     }
@@ -3617,13 +3619,24 @@ mod_chanmode_parse(struct chanNode *channel, char **modes, unsigned int argc, un
         case 'a': do_chan_mode(MODE_ADMINSONLY); break;
         case 'Z': do_chan_mode(MODE_SSLONLY); break;
 	case 'L': do_chan_mode(MODE_HIDEMODE); break;
-	case 'R':
-	  /* MODE_REGISTERED wire letter (nefarious channel.c MODE_REGISTERED,
-	   * server-origin-only). MCP_REGISTERED is passed by the ChanServ
-	   * MODE-lock/mode-command call sites to forbid a user-typed mode
-	   * string from toggling registration state; server-origin calls
-	   * (cmd_mode, AddChannel/BURST via MCP_FROM_SERVER) don't set it,
-	   * so the ircd is free to correct our copy. */
+	case 'z': /* X3's historical/current wire letter for this bit (the
+	           * bit itself descends from Bahamut's +r concept; the 'z'
+	           * mapping is X3's own) */
+	case 'R': /* nefarious MODE_REGISTERED marker; fork bursts it once
+	           * the persist-mirror sets the bit */
+	  /* MODE_REGISTERED: parse LIBERALLY (both letters), emit
+	   * conservatively ('z' only -- see mod_chanmode_format below and
+	   * the registered-mode z->R transition plan). On nefarious, 'z'
+	   * is the persist exmode: services-settable only, and X3's
+	   * emitting it on registered channels doubles as the keep-alive
+	   * those channels want. 'R' is upstream's inert registered
+	   * marker, given real semantics on the fork; parsing it too keeps
+	   * us coherent when a fork server bursts +R alongside +z.
+	   * MCP_REGISTERED is passed by the ChanServ MODE-lock/mode-command
+	   * call sites to forbid a user-typed mode string from toggling
+	   * registration state; server-origin calls (cmd_mode,
+	   * AddChannel/BURST via MCP_FROM_SERVER) don't set it, so the
+	   * ircd is free to correct our copy. */
 	  if (!(flags & MCP_REGISTERED)) {
               do_chan_mode(MODE_REGISTERED);
 	  } else {
@@ -3631,13 +3644,6 @@ mod_chanmode_parse(struct chanNode *channel, char **modes, unsigned int argc, un
               return NULL;
 	  }
 	  break;
-	/* 'z' intentionally NOT a case here: on the fork it is the persist
-	 * exmode, unrelated to registration. Falling through to the
-	 * default case makes it silently ignored on server-origin mode
-	 * strings (MCP_FROM_SERVER, e.g. incoming BURST/MODE) and rejects
-	 * the whole string on user-typed ones -- identical treatment to
-	 * every other letter this parser doesn't recognize. Do NOT parse
-	 * it as MODE_REGISTERED here. */
 #undef do_chan_mode
         case 'l':
             if (add) {
@@ -3863,7 +3869,7 @@ mod_chanmode_announce(struct userNode *who, struct chanNode *channel, struct mod
         DO_MODE_CHAR(NOAMSG, 'T');
         DO_MODE_CHAR(OPERSONLY, 'O');
         DO_MODE_CHAR(ADMINSONLY, 'a');
-        DO_MODE_CHAR(REGISTERED, 'R');
+        DO_MODE_CHAR(REGISTERED, 'z'); /* emit 'z' (not 'R') until the z->R transition; parse accepts both */
         DO_MODE_CHAR(SSLONLY, 'Z');
 	DO_MODE_CHAR(HIDEMODE, 'L');
 #undef DO_MODE_CHAR
@@ -3920,7 +3926,7 @@ mod_chanmode_announce(struct userNode *who, struct chanNode *channel, struct mod
         DO_MODE_CHAR(NOAMSG, 'T');
         DO_MODE_CHAR(OPERSONLY, 'O');
         DO_MODE_CHAR(ADMINSONLY, 'a');
-        DO_MODE_CHAR(REGISTERED, 'R');
+        DO_MODE_CHAR(REGISTERED, 'z'); /* emit 'z' (not 'R') until the z->R transition; parse accepts both */
         DO_MODE_CHAR(SSLONLY, 'Z');
 	DO_MODE_CHAR(HIDEMODE, 'L');
 #undef DO_MODE_CHAR
@@ -3996,7 +4002,7 @@ mod_chanmode_format(struct mod_chanmode *change, char *outbuff)
         DO_MODE_CHAR(NOAMSG, 'T');
         DO_MODE_CHAR(OPERSONLY, 'O');
         DO_MODE_CHAR(ADMINSONLY, 'a');
-        DO_MODE_CHAR(REGISTERED, 'R');
+        DO_MODE_CHAR(REGISTERED, 'z'); /* emit 'z' (not 'R') until the z->R transition; parse accepts both */
         DO_MODE_CHAR(SSLONLY, 'Z');
 	DO_MODE_CHAR(HIDEMODE, 'L');
 #undef DO_MODE_CHAR
@@ -4021,7 +4027,7 @@ mod_chanmode_format(struct mod_chanmode *change, char *outbuff)
         DO_MODE_CHAR(NOAMSG, 'T');
         DO_MODE_CHAR(OPERSONLY, 'O');
         DO_MODE_CHAR(ADMINSONLY, 'a');
-        DO_MODE_CHAR(REGISTERED, 'R');
+        DO_MODE_CHAR(REGISTERED, 'z'); /* emit 'z' (not 'R') until the z->R transition; parse accepts both */
         DO_MODE_CHAR(SSLONLY, 'Z');
 	DO_MODE_CHAR(HIDEMODE, 'L');
 
@@ -4088,8 +4094,7 @@ clear_chanmode(struct chanNode *channel, const char *modes)
         case 'O': cleared |= MODE_OPERSONLY; break;
         case 'a': cleared |= MODE_ADMINSONLY; break;
         case 'R': cleared |= MODE_REGISTERED; break;
-        /* 'z' is the fork's persist exmode, not MODE_REGISTERED; unmatched
-         * letters here are already silently ignored (no default needed). */
+        case 'z': cleared |= MODE_REGISTERED; break; /* current wire letter; 'R' kept for the transition */
         case 'Z': cleared |= MODE_SSLONLY; break;
 	case 'L': cleared |= MODE_HIDEMODE; break;
         }


### PR DESCRIPTION
Split out of #57 (which is now the channel-rename half only). Fixes X3's registered-channel wire marker so nefarious2's registered-channel logic can actually trigger.

## What this does

- **Registered channels are now marked `+R` on the wire.** X3's `MODE_REGISTERED` letter was the Bahamut-era `z` — which nefarious2 doesn't use for registered (on the fork `z` is the *persist* exmode). Remapped to `R`, nefarious2's actual server-settable registered mode. Announced unconditionally at register / unregister / move / db-load — previously all gated on `off_channel > 0`, so with a bot in the channel the ircd was never told the channel was registered. Without this, no ircd-side registered-channel logic (rename arbitration, registered-only history retention, etc.) could ever fire.
- **Heal-on-join**: `handle_join` re-asserts the marker on a registered channel the ircd doesn't currently show as `+R` (ircd restarts, X3 restarts racing the first post-restart JOIN, channel re-creation). Only the first joiner triggers a wire MODE; later joins in the same burst see the bit set and no-op.
- **`z` (persist) split from `R` (registered) properly** — new `MODE_PERSIST` bit tracks `+z`. ChanServ sets `+z` alongside `+R` exactly when `off_channel > 0` (no bot presence to hold the channel open — `+z`'s original purpose), clears both on unregister so an unregistered channel can die when it empties. `cmd_burst` strips both markers from a channel that isn't registered with us. User-typed mode strings (`MCP_REGISTERED` call sites: modelock / mode command) may not toggle either server-managed marker; server-origin strings parse both so X3's copy tracks the ircd.
- **`wipeout_channel` parses burst modes as server-origin** (`MCP_FROM_SERVER`). Previously one unknown mode letter aborted the whole parse, stranding a channel's mode mirror at zero on every X3 restart.

## Commit history note

The three z/R commits show the design being worked out in-branch (`+R` → "keep `z` on the wire for now" → proper split). Happy to squash them to one if preferred; kept as-is so the reasoning in each message survives.

## Related

- #57 — channel rename (RN handler / AC R arbitration). Functionally wants this merged first: the ircd only arbitrates renames for channels it sees as registered.
- Nefarious side: registered-mode semantics live in the fork's `channel.c` `MODE_REGISTERED`.

## Verification

Live E2E on the Afternet testnet against the fork: `+R` visible on registered channels at register / db-load / rejoin after ircd restart; `-R` on unregister; `+z` only when `off_channel > 0`. Registered-channel-gated ircd behaviour (rename arbitration in #57) exercised end-to-end. Vitest coverage in the testnet repo (`channel-rename-services.test.ts`, `persistence-profile.test.ts`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
